### PR TITLE
simplify environment.yml to avoid documenting dependencies twice

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,12 +5,5 @@ channels:
 dependencies:
   - python>=3.9
   - pip
-  # For packaging, and testing
-  - build
-  - setuptools>=61
-  - setuptools_scm>=6.2
-  - pytest
-  - pytest-cov
-  - responses
-  # For running
-  - requests
+  - pip:
+      - --editable .[develop]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,10 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 develop = [
+    "build",
     "pytest",
     "pytest-cov",
-    "responses"
+    "responses",
 ]
 
 [project.urls]


### PR DESCRIPTION
This saves the user from having to do `python -m pip install -e .` after building the conda environment, so the Development instructions in the readme work as written.

I confirmed `python -m build` succeeds. No need to document setuptools and setuptools_scm in the develop requirements since they're documented in the build-system requirements.